### PR TITLE
set correct type to BaseTranslation file

### DIFF
--- a/src/i18n/de/index.ts
+++ b/src/i18n/de/index.ts
@@ -1,6 +1,6 @@
-import type { Translation } from '../i18n-types';
+import type { BaseTranslation } from '../i18n-types';
 
-const de: Translation = {
+const de: BaseTranslation = {
 	connectionStatus: 'Sie sind derzeit Offline',
 	nav: {
 		login: 'Einloggen',


### PR DESCRIPTION
Hi,

thanks for using `typesafe-i18n`. I just saw that you are using the wrong type for your BaseTranslation file 'de'. This PR fixes it